### PR TITLE
[GEOS-10689] separate collector thread and monitor

### DIFF
--- a/src/main/src/main/java/org/geoserver/system/status/BaseSystemInfoCollector.java
+++ b/src/main/src/main/java/org/geoserver/system/status/BaseSystemInfoCollector.java
@@ -33,10 +33,10 @@ public class BaseSystemInfoCollector implements SystemInfoCollector, Serializabl
     }
 
     /**
-     * Retrieve one or more metric for each element defined in {@link MetricInfo}
+     * Retrieve one or more metric values for a {@link MetricInfo} element.
      *
      * @param info the element to retrieve
-     * @return a list of {@link MetricValue} for each {@link MetricInfo}
+     * @return a list of {@link MetricValue} for the {@link MetricInfo} element.
      */
     List<MetricValue> retrieveSystemInfo(MetricInfo info) {
         MetricValue mv = new MetricValue(info);

--- a/src/main/src/main/java/org/geoserver/system/status/MetricInfo.java
+++ b/src/main/src/main/java/org/geoserver/system/status/MetricInfo.java
@@ -47,10 +47,10 @@ public enum MetricInfo {
     GEOSERVER_THREADS("GEOSERVER", 1301, "GeoServer threads"),
     GEOSERVER_JVM_MEMORY_USAGE("GEOSERVER", 1302, "GeoServer JVM memory usage", "%");
 
-    private String category;
-    private int priority;
-    private String description;
-    private String unit;
+    private final String category;
+    private final int priority;
+    private final String description;
+    private final String unit;
 
     MetricInfo(String category, int priority, String description) {
         this(category, priority, description, "");

--- a/src/main/src/main/java/org/geoserver/system/status/Metrics.java
+++ b/src/main/src/main/java/org/geoserver/system/status/Metrics.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 public class Metrics {
 
-    private List<MetricValue> metrics = new ArrayList<>();
+    private final List<MetricValue> metrics = new ArrayList<>();
 
     public List<MetricValue> getMetrics() {
         return metrics;

--- a/src/main/src/main/java/org/geoserver/system/status/OSHISystemInfoMonitor.java
+++ b/src/main/src/main/java/org/geoserver/system/status/OSHISystemInfoMonitor.java
@@ -1,0 +1,132 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.system.status;
+
+import java.util.List;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * Retrieve real system information metrics defined in {@link MetricInfo} from a collector thread.
+ * The collector thread is started and stopped according to the statistics status.
+ *
+ * <p>This class is located as a singleton bean by a &lt;context:component-scan
+ * base-package="org.geoserver.system.status"/&lgt;
+ *
+ * @author d.stueken
+ * @author sandr
+ */
+@Component
+public class OSHISystemInfoMonitor extends BaseSystemInfoCollector implements DisposableBean {
+
+    private static final long serialVersionUID = 502867203324474735L;
+
+    public static String NAME = OSHISystemInfoCollector.class.getSimpleName();
+
+    // collector thread is started on demand.
+    private transient OSHISystemInfoCollector collector;
+
+    public OSHISystemInfoMonitor() {
+        if (getStatisticsStatus() == ENABLED) {
+            // initial startup (currently false by default)
+            collector = start();
+        }
+    }
+
+    /**
+     * Delegate to the collector thread.
+     *
+     * @param info the element to retrieve
+     * @return the values of the MetricInfo element.
+     */
+    @Override
+    List<MetricValue> retrieveSystemInfo(MetricInfo info) {
+        if (getStatisticsStatus() == ENABLED) {
+            return getCollector().retrieveSystemInfo(info);
+        } else {
+            // this returns an empty list of values.
+            return super.retrieveSystemInfo(info);
+        }
+    }
+
+    /**
+     * Get the current collector thread or start a new one.
+     *
+     * @return the started collector thread.
+     */
+    private OSHISystemInfoCollector getCollector() {
+        try {
+            // defensive copy
+            OSHISystemInfoCollector thread = collector;
+            if (thread == null || !thread.isAlive()) {
+                thread = start();
+                collector = thread;
+            }
+            return thread;
+        } catch (Throwable e) {
+            // in case of an error, collection is turned off.
+            collector = null;
+            super.setStatisticsStatus(DISABLED);
+            throw e;
+        }
+    }
+
+    /**
+     * Create and start a collector thread.
+     *
+     * @return a running OSHISystemInfoCollector.
+     */
+    private static OSHISystemInfoCollector start() {
+        OSHISystemInfoCollector collector = new OSHISystemInfoCollector();
+        // easier to locate on debugger.
+        collector.setName(NAME);
+        // system shutdown is not blocked by this thread.
+        collector.setDaemon(true);
+        collector.start();
+        return collector;
+    }
+
+    /**
+     * This is merely used by unit test only.
+     *
+     * @return if the thread is running.
+     */
+    public boolean isRunning() {
+        return collector != null;
+    }
+
+    /** Stop any running collector. */
+    void stop() {
+        // defensive copy
+        final Thread thread = collector;
+        if (thread != null) {
+            collector = null;
+            // Interrupt the thread, no need to wait for termination.
+            thread.interrupt();
+        }
+    }
+
+    /**
+     * Enable or disable the collector. This also starts or stops the collector thread.
+     *
+     * @param status if statistics shall be collected.
+     */
+    @Override
+    public void setStatisticsStatus(Boolean status) {
+        if (status == ENABLED) {
+            getCollector();
+        } else {
+            stop();
+        }
+        // in case of an error the state is left unchanged
+        super.setStatisticsStatus(status);
+    }
+
+    /** Shutdown the collector thread if the bean gets disposed. */
+    @Override
+    public void destroy() {
+        stop();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/system/status/SystemInfoCollector.java
+++ b/src/main/src/main/java/org/geoserver/system/status/SystemInfoCollector.java
@@ -13,6 +13,9 @@ package org.geoserver.system.status;
  */
 public interface SystemInfoCollector {
 
+    boolean ENABLED = true;
+    boolean DISABLED = false;
+
     /** @return the list of metric */
     Metrics retrieveAllSystemInfo();
 

--- a/src/main/src/test/java/org/geoserver/system/status/SystemInfoCollectorTest.java
+++ b/src/main/src/test/java/org/geoserver/system/status/SystemInfoCollectorTest.java
@@ -21,8 +21,8 @@ public class SystemInfoCollectorTest extends GeoServerSystemTestSupport {
 
     @Test
     public void testMetricCollector() {
-        final OSHISystemInfoCollector systemInfoCollector =
-                GeoServerExtensions.bean(OSHISystemInfoCollector.class);
+        final SystemInfoCollector systemInfoCollector =
+                GeoServerExtensions.bean(SystemInfoCollector.class);
         final Metrics collected = systemInfoCollector.retrieveAllSystemInfo();
         final List<MetricValue> metrics = collected.getMetrics();
         for (MetricValue m : metrics) {
@@ -36,12 +36,16 @@ public class SystemInfoCollectorTest extends GeoServerSystemTestSupport {
     }
 
     @Test
-    public void testStatisticsEnabled() {
-        final OSHISystemInfoCollector systemInfoCollector =
-                GeoServerExtensions.bean(OSHISystemInfoCollector.class);
+    public void testStatisticsEnabled() throws InterruptedException {
+        final SystemInfoCollector systemInfoCollector =
+                GeoServerExtensions.bean(SystemInfoCollector.class);
 
         // enable the statistics
         systemInfoCollector.setStatisticsStatus(true);
+
+        // leave it working some time.
+        Thread.sleep(3 * OSHISystemInfoCollector.INTERVAL);
+
         final Metrics collected = systemInfoCollector.retrieveAllSystemInfo();
         final List<MetricValue> metrics = collected.getMetrics();
 
@@ -51,8 +55,8 @@ public class SystemInfoCollectorTest extends GeoServerSystemTestSupport {
 
     @Test
     public void testStatisticsDisabled() {
-        final OSHISystemInfoCollector systemInfoCollector =
-                GeoServerExtensions.bean(OSHISystemInfoCollector.class);
+        final OSHISystemInfoMonitor systemInfoCollector =
+                GeoServerExtensions.bean(OSHISystemInfoMonitor.class);
 
         // disable the statistics
         systemInfoCollector.setStatisticsStatus(false);
@@ -63,5 +67,20 @@ public class SystemInfoCollectorTest extends GeoServerSystemTestSupport {
         for (MetricValue m : metrics) {
             Assert.assertEquals(BaseSystemInfoCollector.DEFAULT_VALUE, m.getValue());
         }
+
+        // find if the collector has stopped.
+        Assert.assertFalse(systemInfoCollector.isRunning());
+    }
+
+    @Override
+    protected void destroyGeoServer() {
+
+        final OSHISystemInfoMonitor systemInfoCollector =
+                GeoServerExtensions.bean(OSHISystemInfoMonitor.class);
+
+        super.destroyGeoServer();
+
+        // find if the collector has stopped.
+        Assert.assertFalse(systemInfoCollector.isRunning());
     }
 }


### PR DESCRIPTION
`OSHISystemInfoCollector`  is a singleton bean to collect system statistics. It creates some `SystemInfo` context and starts a thread to work upon them. A thread is created using an inline lambda expression to implement the collector loop.

This manifests several flaws:

- the implemented loop was taken from [some sample code](https://github.com/oshi/oshi/issues/372) to monitor a _separate_ process. However, in our loop we are observing _our self_. So, the `while (processExists)` loop runs forever.
- the thread is not a _daemon_ thread. Thus the VM will not terminate voluntarily.
- the bean runs on a different thread, so some variables must be volatile.
- the bean must be `Serializable`, thus the objects used by the thread can not be final. Even worse: they have to be transient.
- even if the bean saves its state, the `SystemInfo` context is never restored again.

So, I split it into two different classes:

- A separate collector thread to hold the necessary `SystemInfo` context and statistics results on its own.
- A bean to manage the status and the life cycle of the thread accordingly.

This way both life cycles are decoupled cleanly and the bean may be a `DisposableMonitor` now. The only remaining transient value of the bean is the collector thread, which does not harm and is restored on demand.

I decided to create a new class for the bean named `OSHISystemInfoBean` and use the former class `OSHISystemInfoCollector` to implement the thread, since it finally performs the actual collection. This way also the history of most of the code remains stable.

I added unit tests to verify that the collector thread was (re)started and is finally stopped.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).
