### PR TITLE
[10705] Loading missing resources creates unsolicited empty files

### DIFF
--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataTemplateServiceImpl.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataTemplateServiceImpl.java
@@ -6,7 +6,6 @@ package org.geoserver.metadata.data.service.impl;
 
 import com.thoughtworks.xstream.io.StreamException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -104,14 +103,14 @@ public class MetadataTemplateServiceImpl implements MetadataTemplateService, Res
             Resource listFile = folder.get(LIST_FILE);
 
             if (Resources.exists(listFile)) {
-                try (InputStream inPriorities = listFile.in()) {
-                    List<String> priorities = persister.load(inPriorities, List.class);
+                try {
+                    List<String> priorities = persister.load(listFile, List.class);
 
                     for (String id : priorities) {
                         Resource templateFile = folder.get(id + ".xml");
-                        try (InputStream inTemplate = templateFile.in()) {
+                        try {
                             MetadataTemplate template =
-                                    persister.load(inTemplate, MetadataTemplate.class);
+                                    persister.load(templateFile, MetadataTemplate.class);
                             templates.add(template);
                         } catch (StreamException | IOException e) {
                             LOGGER.log(Level.SEVERE, e.getMessage(), e);

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfigPersister.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfigPersister.java
@@ -9,7 +9,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.thoughtworks.xstream.XStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -72,9 +71,7 @@ public class GWCConfigPersister {
         XStreamPersister xmlPersister = this.persisterFactory.createXMLPersister();
         configureXstream(xmlPersister.getXStream());
         try {
-            try (InputStream in = configFile.in()) {
-                this.config = xmlPersister.load(in, GWCConfig.class);
-            }
+            this.config = xmlPersister.load(configFile, GWCConfig.class);
             LOGGER.fine("GWC GeoServer specific configuration loaded from " + GWC_CONFIG_FILE);
         } catch (Exception e) {
             LOGGER.log(

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -1096,9 +1096,7 @@ public abstract class GeoServerLoader {
 
     /** Helper method which uses xstream to depersist an object as xml from disk. */
     <T> T depersist(XStreamPersister xp, Resource f, Class<T> clazz) throws IOException {
-        try (InputStream in = new ByteArrayInputStream(f.getContents())) {
-            return xp.load(in, clazz);
-        }
+        return xp.load(f, clazz);
     }
 
     /** Helper method which uses xstream to depersist an object as xml from disk. */

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamServiceLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamServiceLoader.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.config.util;
 
-import java.io.BufferedInputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,10 +52,8 @@ public abstract class XStreamServiceLoader<T extends ServiceInfo> implements Ser
 
         if (Resources.exists(file = directory.get(getFilename()))) {
             // xstream it in
-            try (BufferedInputStream in = new BufferedInputStream(file.in())) {
-                XStreamPersister xp = getXstreamPersister(gs);
-                return initialize(xp.load(in, getServiceClass()));
-            }
+            T service = getXstreamPersister(gs).load(file, getServiceClass());
+            return initialize(service);
         } else {
             // create an 'empty' object
             T service = createServiceFromScratch(gs);

--- a/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingStartupContextListener.java
@@ -5,7 +5,6 @@
  */
 package org.geoserver.logging;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -120,10 +119,7 @@ public class LoggingStartupContextListener implements ServletContextListener {
         Resource f = store.get("logging.xml");
         if (f != null && f.getType() == Resource.Type.RESOURCE) {
             XStreamPersister xp = new XStreamPersisterFactory().createXMLPersister();
-            try (BufferedInputStream in = new BufferedInputStream(f.in())) {
-                LoggingInfo loginfo = xp.load(in, LoggingInfo.class);
-                return loginfo;
-            }
+            return xp.load(f, LoggingInfo.class);
         } else {
             return null;
         }

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -2699,17 +2699,13 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
     /** reads a config file from the specified directly using the specified xstream persister */
     <T extends SecurityConfig> T loadConfig(Class<T> config, Resource resource, XStreamPersister xp)
             throws IOException {
-        try (InputStream in = resource.in()) {
-            Object loaded = xp.load(in, SecurityConfig.class).clone(true);
-            return config.cast(loaded);
-        }
+        Object loaded = xp.load(resource, SecurityConfig.class).clone(true);
+        return config.cast(loaded);
     }
     /** reads a config file from the specified directly using the specified xstream persister */
     SecurityConfig loadConfigFile(Resource directory, String filename, XStreamPersister xp)
             throws IOException {
-        try (InputStream fin = directory.get(filename).in()) {
-            return xp.load(fin, SecurityConfig.class).clone(true);
-        }
+        return xp.load(directory.get(filename), SecurityConfig.class).clone(true);
     }
 
     /**

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileSystemResourceStore.java
@@ -201,7 +201,8 @@ public class FileSystemResourceStore implements ResourceStore {
 
         @Override
         public InputStream in() {
-            File actualFile = file();
+            // just take the File as is, don't create it.
+            File actualFile = this.file;
             if (!actualFile.exists()) {
                 throw new IllegalStateException("File not found " + actualFile);
             }

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -77,7 +77,8 @@ public final class Files {
 
         @Override
         public InputStream in() {
-            final File actualFile = file();
+            // just take the File as is, don't create it.
+            final File actualFile = this.file;
             if (!actualFile.exists()) {
                 throw new IllegalStateException("Cannot access " + actualFile);
             }

--- a/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/ResourceTheoryTest.java
@@ -126,15 +126,15 @@ public abstract class ResourceTheoryTest {
     }
 
     @Theory
-    public void theoryUndefinedHaveIstreamAndBecomeResource(String path) throws Exception {
+    public void theoryUndefinedHaveNoIstreams(String path) throws Exception {
         Resource res = getResource(path);
 
         assumeThat(res, is(undefined()));
 
-        try (InputStream result = res.in()) {
-            assertThat(result, notNullValue());
-            assertThat(res, is(resource()));
-        }
+        assertThrows(IllegalStateException.class, () -> res.in().close());
+
+        // must not be created unintentionally.
+        assertThat(res, is(undefined()));
     }
 
     @Theory


### PR DESCRIPTION
[10705]

After merging [GEOS-10723] [GEOS-10724] and [GEOS-10743], we can finally realize the idea to throw an Exception on Resource.in() if the file does not exist. 

Finally `XStreamPersister.load(InputStream)` is affected by this change, too. All usages already have some error handling block. But they are sensitive on `IOException` but not on `IllegalStateException`. So I introduced a new XStreamPersister.load(Resource) method which throws an `FileNotFoundException` if the resource is not of `Type.RESOURCE`.
This replaces the boilerplate try/resource block and integrates smoothly, since `IOException` is expected.

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).